### PR TITLE
Add default export to definition file

### DIFF
--- a/src/cssModuleToInterface.js
+++ b/src/cssModuleToInterface.js
@@ -95,5 +95,6 @@ ${interfaceProperties}
 }
 
 export const locals: ${interfaceName};
+export default locals;
 `);
 };


### PR DESCRIPTION
from https://github.com/Jimdo/typings-for-css-modules-loader/pull/51 by @sarink 
> When using the `style-loader`, the `locals` object gets invisibly murdered. Fixes https://github.com/Jimdo/typings-for-css-modules-loader/issues/20. If someone's not using the `style-loader` they can `import {locals}`, and if they _are_ using the `style-loader`, they can use the default import. This should make everyone happy, and be fully backwards-compatible.