### PR TITLE
New feature: added support default export from babel

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -28,13 +28,17 @@ const schema = {
       enum: ["prettier", "none"]
     },
     disableLocalsExport: {
-      description:
-        "Disable the use of locals export. Defaults to `false`",
+      description: "Disable the use of locals export. Defaults to `false`",
       type: "boolean"
     },
     verifyOnly: {
       description:
         "Validate generated `*.d.ts` files and fail if an update is needed (useful in CI). Defaults to `false`",
+      type: "boolean"
+    },
+    useDefaultExport: {
+      description:
+        "Enable the use of locals default export. Defaults to `false`",
       type: "boolean"
     }
   },
@@ -81,7 +85,8 @@ module.exports = function(content, ...args) {
   const cssModuleDefinition = generateGenericExportInterface(
     cssModuleKeys,
     filenameToPascalCase(filename),
-    options.disableLocalsExport
+    options.disableLocalsExport,
+    options.useDefaultExport
   );
 
   applyFormattingAndOptions(cssModuleDefinition, options)

--- a/src/utils.js
+++ b/src/utils.js
@@ -46,13 +46,22 @@ const filenameToTypingsFilename = filename => {
 /**
  * @param {string[]} cssModuleKeys
  * @param {string} pascalCaseFileName
+ * @param {string | boolean} disableLocalsExport
+ * @param {string | boolean} useDefaultExport
  */
-const generateGenericExportInterface = (cssModuleKeys, pascalCaseFileName, disableLocalsExport) => {
+const generateGenericExportInterface = (
+  cssModuleKeys,
+  pascalCaseFileName,
+  disableLocalsExport,
+  useDefaultExport
+) => {
   const interfaceName = `I${pascalCaseFileName}`;
   const moduleName = `${pascalCaseFileName}Module`;
   const namespaceName = `${pascalCaseFileName}Namespace`;
 
-  const localsExportType = disableLocalsExport ? `` : ` & {
+  const localsExportType = disableLocalsExport
+    ? ``
+    : ` & {
   /** WARNING: Only available when \`css-loader\` is used without \`style-loader\` or \`mini-css-extract-plugin\` */
   locals: ${namespaceName}.${interfaceName};
 }`;
@@ -69,7 +78,7 @@ ${interfaceProperties}
 
 declare const ${moduleName}: ${namespaceName}.${interfaceName}${localsExportType};
 
-export = ${moduleName};`;
+export ${useDefaultExport ? "default" : "="} ${moduleName};`;
 };
 
 module.exports = {


### PR DESCRIPTION
In options use "useDefaultExport: true" to avoid the following error "babel plugin-transfrom-typescript does not support `export =` syntax"