### PR TITLE
Fix Travis build testing latest dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,12 @@ branches:
 jobs:
   include:
     - install: npm ci
-    - install: npm install --no-shrinkwrap
+      env: USING_PACKAGE_LOCK=true
+      cache: npm
+    - install: npm install
+      before_install: rm package-lock.json
+      env: USING_PACKAGE_LOCK=false
+      cache: false
 
 before_script:
-  - npm ls css-loader
-  - npm ls typescript
+  - npm ls --depth=0


### PR DESCRIPTION
It looks like `npm ls css-loader` does not work when installing packages ignoring package-lock to run tests with the latest dependencies.
The issue seems to be when deleting package-lock before `npm install` instead of running npm install ignoring package-lock `npm install --no-shrinkwrap`. 
