### PR TITLE
Support nordic characters in CSS class names

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -7,7 +7,7 @@ const camelCase = require("camelcase");
  * @returns {string[]}
  */
 const getCssModuleKeys = (content) => {
-  const keyRegex = /"([^:")][^")]*)":/g;
+  const keyRegex = /"([^"\n]+)":/g;
   let match;
   const cssModuleKeys = [];
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -7,7 +7,7 @@ const camelCase = require("camelcase");
  * @returns {string[]}
  */
 const getCssModuleKeys = (content) => {
-  const keyRegex = /"([\w-]+)":/g;
+  const keyRegex = /"([^:")][^")]*)":/g;
   let match;
   const cssModuleKeys = [];
 

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -60,4 +60,14 @@ describe("getCssModuleKeys", () => {
     const actual = getCssModuleKeys(content);
     expect(actual).toEqual([]);
   });
+
+  it("CSS module with special class names", () => {
+    const content = `.locals = {
+      "øæå": "nordic",
+      "+~@": "special",
+      "f\\'o\\'o": "escaped",
+    };`;
+    const actual = getCssModuleKeys(content);
+    expect(actual).toEqual(["øæå", "+~@", "f\\'o\\'o"]);
+  });
 });

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -70,4 +70,13 @@ describe("getCssModuleKeys", () => {
     const actual = getCssModuleKeys(content);
     expect(actual).toEqual(["øæå", "+~@", "f\\'o\\'o"]);
   });
+
+  it("CSS module with newline in class names should be ignored", () => {
+    const content = `.locals = {
+      "line1
+line2": "twolinesdoesnotmakesense"
+    };`;
+    const actual = getCssModuleKeys(content);
+    expect(actual).toEqual([]);
+  });
 });


### PR DESCRIPTION
Make the package support nordic characters in class names again ([and all other valid CSS class selector names](https://mathiasbynens.be/demo/crazy-class)), while supporting an upgrade to css-loader 4 (v2.3.0).

Affects changes made in #27 (v2.2.1)