### PR TITLE
added support for using styles[name] syntax

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -36,6 +36,7 @@ const cssModuleToTypescriptInterfaceProperties = (cssModuleKeys, indent) => {
     .map((key) => `${indent || ""}'${key}': string;`)
 
   properties.push(`${indent || ""}[name: string]: string;`)
+
   return properties.join("\n");
 };
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -31,10 +31,12 @@ const filenameToPascalCase = (filename) => {
  * @param {string=} indent
  */
 const cssModuleToTypescriptInterfaceProperties = (cssModuleKeys, indent) => {
-  return [...cssModuleKeys]
+  const properties = [...cssModuleKeys]
     .sort()
     .map((key) => `${indent || ""}'${key}': string;`)
-    .join("\n");
+
+  properties.push(`${indent || ""}[name: string]: string;`)
+  return properties.join("\n");
 };
 
 const filenameToTypingsFilename = (filename) => {

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -6,6 +6,7 @@ exports[`css-loader@3 default options 1`] = `
     \\"bar-baz\\": string;
     composed: string;
     foo: string;
+    [name: string]: string;
   }
 }
 
@@ -24,6 +25,7 @@ exports[`css-loader@3 localsConvention asIs 1`] = `
     \\"bar-baz\\": string;
     composed: string;
     foo: string;
+    [name: string]: string;
   }
 }
 
@@ -43,6 +45,7 @@ exports[`css-loader@3 localsConvention camelCase 1`] = `
     barBaz: string;
     composed: string;
     foo: string;
+    [name: string]: string;
   }
 }
 
@@ -62,6 +65,7 @@ declare namespace ExampleCssNamespace {
     \\"bar-baz\\": string;
     composed: string;
     foo: string;
+    [name: string]: string;
   }
 }
 
@@ -80,6 +84,7 @@ exports[`css-loader@3 with locals export disabled 1`] = `
     \\"bar-baz\\": string;
     composed: string;
     foo: string;
+    [name: string]: string;
   }
 }
 
@@ -95,6 +100,7 @@ exports[`css-loader@3 with no formatter 1`] = `
     'bar-baz': string;
     'composed': string;
     'foo': string;
+    [name: string]: string;
   }
 }
 
@@ -112,6 +118,7 @@ exports[`css-loader@3 with prettier 1`] = `
     \\"bar-baz\\": string;
     composed: string;
     foo: string;
+    [name: string]: string;
   }
 }
 
@@ -130,6 +137,7 @@ exports[`css-loader@3 with sourcemap 1`] = `
     \\"bar-baz\\": string;
     composed: string;
     foo: string;
+    [name: string]: string;
   }
 }
 
@@ -148,6 +156,7 @@ exports[`css-loader@latest default options 1`] = `
     \\"bar-baz\\": string;
     composed: string;
     foo: string;
+    [name: string]: string;
   }
 }
 
@@ -166,6 +175,7 @@ exports[`css-loader@latest localsConvention asIs 1`] = `
     \\"bar-baz\\": string;
     composed: string;
     foo: string;
+    [name: string]: string;
   }
 }
 
@@ -185,6 +195,7 @@ exports[`css-loader@latest localsConvention camelCase 1`] = `
     barBaz: string;
     composed: string;
     foo: string;
+    [name: string]: string;
   }
 }
 
@@ -204,6 +215,7 @@ declare namespace ExampleCssNamespace {
     \\"bar-baz\\": string;
     composed: string;
     foo: string;
+    [name: string]: string;
   }
 }
 
@@ -222,6 +234,7 @@ exports[`css-loader@latest with locals export disabled 1`] = `
     \\"bar-baz\\": string;
     composed: string;
     foo: string;
+    [name: string]: string;
   }
 }
 
@@ -237,6 +250,7 @@ exports[`css-loader@latest with no formatter 1`] = `
     'bar-baz': string;
     'composed': string;
     'foo': string;
+    [name: string]: string;
   }
 }
 
@@ -254,6 +268,7 @@ exports[`css-loader@latest with prettier 1`] = `
     \\"bar-baz\\": string;
     composed: string;
     foo: string;
+    [name: string]: string;
   }
 }
 
@@ -272,6 +287,7 @@ exports[`css-loader@latest with sourcemap 1`] = `
     \\"bar-baz\\": string;
     composed: string;
     foo: string;
+    [name: string]: string;
   }
 }
 


### PR DESCRIPTION
I needed to do this `<div className={`${styles.box} ${styles[this.props.t]}`}>` but was getting a compile error.

I found by adding `[name:string]: string;` the scss.d.ts file this compile error was fixed and the style was applied correctly

I have updated  cssModuleToTypescriptInterfaceProperties to always add this extra property