### PR TITLE
Add eol after last line when prettier is not used

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -121,6 +121,8 @@ async function applyFormattingAndOptions(cssModuleDefinition, options) {
   ) {
     cssModuleDefinition = await applyPrettier(cssModuleDefinition, options);
   } else {
+    cssModuleDefinition += "\n";
+
     // at very least let's ensure we're using OS eol if it's not provided
     cssModuleDefinition = cssModuleDefinition.replace(
       /\r?\n/g,

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -103,7 +103,8 @@ declare const ExampleCssModule: ExampleCssNamespace.IExampleCss & {
   locals: ExampleCssNamespace.IExampleCss;
 };
 
-export = ExampleCssModule;"
+export = ExampleCssModule;
+"
 `;
 
 exports[`css-loader@3 with prettier 1`] = `
@@ -245,7 +246,8 @@ declare const ExampleCssModule: ExampleCssNamespace.IExampleCss & {
   locals: ExampleCssNamespace.IExampleCss;
 };
 
-export = ExampleCssModule;"
+export = ExampleCssModule;
+"
 `;
 
 exports[`css-loader@latest with prettier 1`] = `


### PR DESCRIPTION
When prettier is used, it can be configured to add a line feed at the end of file. But when it is not used, the line feed after last line is missing.