### PR TITLE
https://github.com/TeamSupercell/typings-for-css-modules-loader/issue…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3008,9 +3008,9 @@
       "dev": true
     },
     "emojis-list": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
-      "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
+      "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q=="
     },
     "end-of-stream": {
       "version": "1.4.4",
@@ -5346,12 +5346,12 @@
       "dev": true
     },
     "loader-utils": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.2.3.tgz",
-      "integrity": "sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.2.tgz",
+      "integrity": "sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==",
       "requires": {
         "big.js": "^5.2.2",
-        "emojis-list": "^2.0.0",
+        "emojis-list": "^3.0.0",
         "json5": "^1.0.1"
       }
     },

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   ],
   "dependencies": {
     "camelcase": "^5.3.1",
-    "loader-utils": "1.2.3",
+    "loader-utils": "^1.4.2",
     "schema-utils": "^2.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
…s/73 Update loader-utils library to the latest patch version with the fix, don't want to upgrade to the latest available version as it two major versions up and I'm not in this repo code and can't guarantee I this update will be smooth.